### PR TITLE
Prepare FlameGraph handler for demo

### DIFF
--- a/lib/sibyl/handlers/flame_graph.ex
+++ b/lib/sibyl/handlers/flame_graph.ex
@@ -1,0 +1,144 @@
+defmodule Sibyl.Handlers.FlameGraph do
+  @moduledoc """
+  An example Telemetry handler converting `:telemetry` events into Chrome-compatible
+  flamegraphs.
+
+  Exposes two additional functions when compared to traditional `Sibyl.Handler`s:
+
+  1) `start/0` which instructs #{__MODULE__} to start persisting metadata in order
+     to build the resultant flamegraph.
+
+  2) `stop/1` which instructs #{__MODULE__} to flush any captured metadata into a
+     JSON file for further use.
+
+  If you're using a Chrome-derived browser, you'll be able to open and introspect
+  generated flamegraphs via the [Chrome Tracing](chrome://tracing) builtin. Otherwise,
+  you can use open source tools which understand Chrome Tracing's format to render
+  graphs.
+
+  Examples of open source apps that can render Chrome Traces include
+  [Speedscope](https://www.speedscope.app/) and [Perfetto](https://perfetto.dev/).
+
+  Note that this utility has only been tested and confirmed working with telemetry
+  explicitly passed in via `Sibyl` and may not work when listening to arbitrary
+  `:telemetry` events passed in from other OTP applications.
+
+  Notes on the file format used by Google's tracer, Speedscope, and other related tools
+  [can be found here](https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/edit#).
+  """
+
+  @behaviour Sibyl.Handler
+
+  alias __MODULE__
+  require Logger
+
+  @doc """
+  Instructs #{__MODULE__} to start capturing and persisting `:telemetry` metadata.
+  """
+  @spec start :: :ok
+  def start do
+    if started?() do
+      raise ArgumentError,
+        message: "#{FlameGraph} is already started. Only one instance can run at any given time."
+    end
+
+    init_ets()
+    :ok
+  end
+
+  defp init_ets do
+    unless started?() do
+      :ets.new(FlameGraph, [:duplicate_bag, :public, :named_table, write_concurrency: true])
+    end
+
+    :ok
+  end
+
+  @doc """
+  Returns `true` if #{FlameGraph} has been started prior to invokation.
+  """
+  @spec started?() :: boolean()
+  def started?, do: :ets.whereis(FlameGraph) != :undefined
+
+  @doc """
+  Instructs #{__MODULE__} to output any captured `:telemetry` metadata into the JSON
+  file of your choice.
+  """
+  @spec stop(output_filepath :: Path.t()) :: :ok
+  def stop(output_filepath) do
+    unless started?() do
+      raise ArgumentError,
+        message: """
+        #{FlameGraph} was not started. Please ensure you start #{FlameGraph} before stopping.
+        """
+    end
+
+    metadata_export = :ets.tab2list(FlameGraph)
+    true = :ets.delete(FlameGraph)
+
+    pids =
+      metadata_export
+      |> Enum.map(&elem(&1, 0))
+      |> Enum.uniq()
+      |> Map.new(fn pid ->
+        {parsed, _rest} =
+          pid
+          |> inspect()
+          |> String.trim_leading("#PID<")
+          |> String.trim_trailing(">")
+          |> String.replace(".", "")
+          |> Integer.parse()
+
+        {pid, parsed}
+      end)
+
+    trace_events = Enum.map(metadata_export, fn {pid, data} -> Map.put(data, :pid, pids[pid]) end)
+
+    File.write!(
+      output_filepath,
+      Jason.encode!(%{
+        "traceEvents" => trace_events,
+        "meta_user" => "#{FlameGraph}",
+        "meta_cpu_count" => "#{:erlang.system_info(:logical_processors_available)}"
+      })
+    )
+  end
+
+  @impl Sibyl.Handler
+  def handle_event(event, measurement, metadata, _config) do
+    if started?() do
+      event
+      |> List.pop_at(length(event) - 1)
+      |> do_handle_event(measurement, metadata)
+    else
+      :ok
+    end
+  end
+
+  # TODO: for `exception` events, we should persist custom metadata to call out
+  # the fact that we've thrown an exception.
+  defp do_handle_event({event, mfa}, measurement, metadata) when event in [:stop, :exception] do
+    pid = self()
+    %{monotonic_time: monotonic_time, duration: duration} = measurement
+    %{args: args} = metadata
+
+    :ets.insert(
+      FlameGraph,
+      {pid,
+       %{
+         tid: 1,
+         ts: monotonic_time - duration,
+         dur: duration,
+         ph: "X",
+         name: Enum.join(mfa, "."),
+         args: args
+       }}
+    )
+
+    :ok
+  end
+
+  defp do_handle_event(_event, _measurement, _metadata) do
+    :ok
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -60,6 +60,7 @@ defmodule Sibyl.MixProject do
   defp deps do
     [
       # Sibyl's actual dependencies
+      {:jason, "~> 1.3"},
       {:decorator, "~> 1.2"},
       {:opentelemetry, "~> 1.0"},
       {:opentelemetry_api, "~> 1.0"},

--- a/test/sibyl/handlers/flame_graph_test.exs
+++ b/test/sibyl/handlers/flame_graph_test.exs
@@ -1,0 +1,92 @@
+defmodule Sibyl.Handlers.FlameGraphTest do
+  use ExUnit.Case, async: false
+
+  alias Sibyl.Handlers.FlameGraph
+  alias Sibyl.Handlers
+
+  describe "start/0" do
+    test "returns `:ok` and initialises state on first run" do
+      refute FlameGraph.started?()
+      assert :ok = FlameGraph.start()
+      assert FlameGraph.started?()
+    end
+
+    test "raises exception if already started" do
+      assert :ok = FlameGraph.start()
+      assert_raise ArgumentError, fn -> FlameGraph.start() end
+    end
+  end
+
+  describe "stop/1" do
+    setup do
+      filepath =
+        :sibyl
+        |> :code.priv_dir()
+        |> Path.join("test.json")
+
+      on_exit(fn -> File.rm(filepath) end)
+
+      {:ok, filepath: filepath}
+    end
+
+    test "raises exception if not already started", ctx do
+      assert_raise ArgumentError, fn -> FlameGraph.stop(ctx.filepath) end
+    end
+
+    test "returns `:ok` and writes empty traces to file if no traces were captured", ctx do
+      assert :ok = FlameGraph.start()
+      assert :ok = FlameGraph.stop(ctx.filepath)
+
+      assert {:ok, data} = File.read(ctx.filepath)
+
+      assert %{
+               "meta_cpu_count" => _cpu_count,
+               "meta_user" => "Elixir.Sibyl.Handlers.FlameGraph",
+               "traceEvents" => []
+             } = Jason.decode!(data)
+    end
+
+    test "returns `:ok` and captures telemetry start/stop events in file", ctx do
+      Code.eval_string("""
+        defmodule FlameGraph1 do
+          use Sibyl
+          @decorate_all trace()
+
+          def hello do
+            world()
+            world()
+            world()
+            something_else()
+            :ok
+          end
+
+          def world, do: :ok
+          def something_else, do: world() && :ok
+        end
+      """)
+
+      assert :ok = FlameGraph.start()
+      assert :ok = Handlers.attach_module_events(FlameGraph1, FlameGraph, name: "flamegraph-test")
+      assert :ok = apply(FlameGraph1, :hello, [])
+      assert :ok = FlameGraph.stop(ctx.filepath)
+
+      assert {:ok, data} = File.read(ctx.filepath)
+
+      assert %{
+               "meta_cpu_count" => _cpu_count,
+               "meta_user" => "Elixir.Sibyl.Handlers.FlameGraph",
+               "traceEvents" => trace_events
+             } = Jason.decode!(data)
+
+      # Sort by timestamp and compare expected function execution order
+      assert [
+               %{"name" => "flame_graph1.hello/0"},
+               %{"name" => "flame_graph1.world/0"},
+               %{"name" => "flame_graph1.world/0"},
+               %{"name" => "flame_graph1.world/0"},
+               %{"name" => "flame_graph1.something_else/0"},
+               %{"name" => "flame_graph1.world/0"}
+             ] = Enum.sort_by(trace_events, & &1["ts"])
+    end
+  end
+end


### PR DESCRIPTION
Implements a simple flamegraph handler based on Chrome's file format as it is widely supported.

This will prove useful when wanting to be able to export a trace, though the implementation is simple and not quite complete yet!

Example file generated:
```json
{
  "meta_cpu_count": "32",
  "meta_user": "Elixir.Sibyl.Handlers.FlameGraph",
  "traceEvents": [
    {
      "args": [],
      "dur": 1490,
      "name": "flame_graph1.world/0",
      "ph": "X",
      "pid": 21590,
      "tid": 1,
      "ts": -576460751085928700
    },
    {
      "args": [],
      "dur": 969,
      "name": "flame_graph1.world/0",
      "ph": "X",
      "pid": 21590,
      "tid": 1,
      "ts": -576460751085922400
    },
    {
      "args": [],
      "dur": 990,
      "name": "flame_graph1.world/0",
      "ph": "X",
      "pid": 21590,
      "tid": 1,
      "ts": -576460751085918850
    },
    {
      "args": [],
      "dur": 1020,
      "name": "flame_graph1.world/0",
      "ph": "X",
      "pid": 21590,
      "tid": 1,
      "ts": -576460751085914100
    },
    {
      "args": [],
      "dur": 3980,
      "name": "flame_graph1.something_else/0",
      "ph": "X",
      "pid": 21590,
      "tid": 1,
      "ts": -576460751085915460
    },
    {
      "args": [],
      "dur": 24479,
      "name": "flame_graph1.hello/0",
      "ph": "X",
      "pid": 21590,
      "tid": 1,
      "ts": -576460751085934000
    }
  ]
}
```

How it should be rendered:
![image](https://user-images.githubusercontent.com/15597865/178239842-2fc84e73-f26d-4dcb-b456-65d149006cca.png)
