### PR TITLE
SYB 009/actual distributed tracing

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -122,7 +122,7 @@ alias Credo.Check
 
           ## Causes Issues with Phoenix ----------------------------------------
           {Check.Readability.Specs, []},
-          {Check.Refactor.ModuleDependencies, [max_deps: 16]},
+          {Check.Refactor.ModuleDependencies, [max_deps: 19]},
 
           ## Optional (move to `disabled` based on app domain) -----------------
           {Check.Refactor.IoPuts, []}

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Sibyl.MixProject do
   def project do
     [
       app: :sibyl,
-      version: "0.1.3",
+      version: "0.1.4",
       elixir: "~> 1.13",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
- Add API functions for serializing and re-attaching parent spans
- Bump version for new distributed trace API and prepare for release
