### PR TITLE
SYB 010/emit event from other modules

### DIFF
--- a/lib/sibyl.ex
+++ b/lib/sibyl.ex
@@ -75,12 +75,14 @@ defmodule Sibyl do
   Sibyl will perform compile time checks prior to attempting to emit an event to make
   sure that it has previously been defined in the current module.
 
-  Thus, it is important to explicitly define events prior to emission, which adds
-  much needed safety when dealing with needing to change/rename events.
-
   Events which are defined in a module are automatically prefixed with that module's
   namespace such that given a module `MyApp.Users` and an event `:registered`, the
   resultant event will be compiled and ultimately emitted as `[:my_app, :users, :registered]`.
+
+  Otherwise, you can specify a module which defined a given event by using `Sibyl.emit/4` over
+  `Sibyl.emit/3`.
+
+  For more in-depth information, see `Sibyl.emit/4`.
 
   Examples follow:
 
@@ -89,7 +91,7 @@ defmodule Sibyl do
     use Sibyl
 
     def sign_up(attrs) do
-      Sibyl.emit(:registered) # Fails to compile as event is unknown.
+      emit :registered  # Fails to compile as event is unknown.
     end
   end
 
@@ -99,7 +101,16 @@ defmodule Sibyl do
     define_event :registered
 
     def sign_up(attrs) do
-      Sibyl.emit(:registered) # Compiles properly and emits event
+      emit :registered  # Compiles properly and emits event
+    end
+  end
+
+  defmodule MyApp.Users.Mailer do
+    use Sibyl
+
+    def send_email do
+      emit MyApp.Users, :registered    # Compiles properly and emits events
+      emit MyApp.Users, :invalid_event # Causes error as this was not defined in specified module
     end
   end
   ```

--- a/lib/sibyl/ast.ex
+++ b/lib/sibyl/ast.ex
@@ -1,0 +1,41 @@
+defmodule Sibyl.AST do
+  @moduledoc """
+  Utility module for working with ASTs
+  """
+
+  @type ast() :: term()
+  @type alias() :: {:__aliases__, term(), [atom()]}
+  @type unused() :: :__unused__
+
+  @doc """
+  Returns true if the given argument is an Elixir AST node representing a module alias
+  such as `Enum`.
+  """
+  defguard alias?(ast) when is_tuple(ast) and elem(ast, 0) == :__aliases__
+
+  @doc """
+  Returns true if the given argument is equal to `:__unused__`. Primarily used internally.
+  """
+  defguard unused?(term) when term == :__unused__
+
+  @doc """
+  Given an alias AST node, returns the fully resolved alias that said node would expand
+  to.
+
+  For example, given: `{:__aliases, unused(), [Elixir, Enum]}`, returns: `Enum`.
+  """
+  @spec module(alias()) :: module()
+  def module({:__aliases__, _metadata, module_list}) do
+    Module.safe_concat(module_list)
+  end
+
+  @doc """
+  Returns the `:__unused__` atom.
+  """
+  @spec unused() :: ast()
+  defmacro unused do
+    quote do
+      :__unused__
+    end
+  end
+end

--- a/lib/sibyl/decorator.ex
+++ b/lib/sibyl/decorator.ex
@@ -17,9 +17,9 @@ defmodule Sibyl.Decorator do
   """
 
   use Decorator.Define, trace: 0
-  require Sibyl.Events
 
-  @type ast() :: term()
+  alias Sibyl.AST
+  require Sibyl.Events
 
   @doc """
   Decorator which wraps a given function with a standard telemetry span.
@@ -37,14 +37,13 @@ defmodule Sibyl.Decorator do
   See [here](https://github.com/beam-telemetry/telemetry/pull/43) for explanations
   w.r.t. anonymous function perf.
   """
-  @spec trace(function_body :: ast(), ctx :: map()) :: ast() | no_return()
+  @spec trace(function_body :: AST.ast(), ctx :: map()) :: AST.ast() | no_return()
   def trace(body, ctx) do
     Application.ensure_all_started(:telemetry)
     event = Sibyl.Events.build_event(ctx.module, ctx.name, ctx.arity)
 
     quote do
       event = unquote(event)
-
       args = unquote(ctx.args)
       module = unquote(inspect(ctx.module))
       function = unquote(ctx.name)
@@ -123,7 +122,7 @@ defmodule Sibyl.Decorator do
   end
 
   @doc false
-  @spec on_definition(env :: map(), term(), atom(), list(term()), ast(), ast()) :: ast()
+  @spec on_definition(env :: map(), term(), atom(), [term()], AST.ast(), AST.ast()) :: AST.ast()
   def on_definition(%{module: module} = env, kind, function, args, guards, body) do
     arity = length(args)
 

--- a/lib/sibyl/exceptions.ex
+++ b/lib/sibyl/exceptions.ex
@@ -1,0 +1,32 @@
+defmodule Sibyl.UndefinedEventError do
+  defexception [:message, :event, :module]
+
+  @impl Exception
+  def exception(event: event, module: module) do
+    %Sibyl.UndefinedEventError{
+      event: event,
+      module: module,
+      message: """
+      Attempted to emit event `#{event}` defined in module `#{inspect(module)}` but no such event was defined.
+      Ensure `#{inspect(module)}` uses `define_event/1` to define `#{event}` before emission.
+      """
+    }
+  end
+end
+
+defmodule Sibyl.BadEmissionError do
+  defexception [:message]
+
+  @impl Exception
+  def exception(args: args) do
+    %Sibyl.BadEmissionError{
+      message: """
+      Emitting events must be done either by `Sibyl.emit/4` or `Sibyl.emit/3` where:
+      - `Sibyl.emit/4` takes a module alias as a first parameter, followed by an atom denoting the event name, an optional map of "measurements", and an optional map of "metadata".
+      - `Sibyl.emit/3` takes either a bare atom or list of atoms (an event name), an optional map of "measurements", and an optional map of "metadata".
+
+      No other argument combination is supported, but got: `#{inspect(args)}`.
+      """
+    }
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Sibyl.MixProject do
   def project do
     [
       app: :sibyl,
-      version: "0.1.4",
+      version: "0.1.5",
       elixir: "~> 1.13",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/sibyl/ast_test.exs
+++ b/test/sibyl/ast_test.exs
@@ -1,0 +1,36 @@
+defmodule Sibyl.Handlers.ASTTest do
+  use ExUnit.Case
+  require Sibyl.AST, as: AST
+
+  describe "alias?/1" do
+    test "returns true when given an AST node which is an alias" do
+      assert AST.alias?({:__aliases__, [line: 16], [MyApp, Users]})
+    end
+
+    test "returns false given anything else" do
+      refute AST.alias?(:atom)
+    end
+  end
+
+  describe "unused?/1" do
+    test "returns true when given `:__unused__`" do
+      assert AST.unused?(:__unused__)
+    end
+
+    test "returns false when given anything else" do
+      refute AST.unused?(nil)
+    end
+  end
+
+  describe "module/1" do
+    test "returns module given a module alias AST node" do
+      assert MyApp.Users = AST.module({:__aliases__, [line: 16], [MyApp.Users]})
+    end
+  end
+
+  describe "unused/0" do
+    test "returns `:__unused__`" do
+      assert :__unused__ = AST.unused()
+    end
+  end
+end

--- a/test/sibyl_test.exs
+++ b/test/sibyl_test.exs
@@ -1,22 +1,92 @@
 defmodule SibylTest do
   use ExUnit.Case
-  use Sibyl
-
-  define_event(:defined)
 
   describe "emit/3" do
-    test "emits events so long as they're defined in this module" do
-      assert :ok = Sibyl.emit(:defined)
-    end
-
     test "raises a compile-time error when trying to emit an event that isn't defined" do
-      assert_raise ArgumentError, fn ->
+      assert_raise Sibyl.UndefinedEventError, fn ->
         Code.eval_string("""
-        defmodule SibylTestCompilationHooks do
+        defmodule SibylTestCompilationHooks1 do
           use Sibyl
 
           def hello do
-            Sibyl.emit(:not_defined)
+            emit :not_defined
+          end
+        end
+        """)
+      end
+    end
+
+    test "does not raise a compile-time error when emitting an event that is defined" do
+      assert Code.eval_string("""
+             defmodule SibylTestCompilationHooks2 do
+               use Sibyl
+
+               define_event :defined
+
+               def hello do
+                 emit :defined
+               end
+             end
+             """)
+    end
+
+    test "does not raise a compile-time error when emitting an event that is a list of atoms" do
+      assert Code.eval_string("""
+             defmodule SibylTestCompilationHooks3 do
+               use Sibyl
+
+               def hello do
+                 emit [:some, :random, :event]
+               end
+             end
+             """)
+    end
+  end
+
+  describe "emit/4" do
+    test "raises a compile-time error when trying to emit an event that isn't defined" do
+      assert_raise Sibyl.UndefinedEventError, fn ->
+        Code.eval_string("""
+        defmodule Emit4Test1 do
+          use Sibyl
+        end
+
+        defmodule SibylTestCompilationHooks4 do
+          use Sibyl
+
+          def hello do
+            emit Emit4Test1, :not_defined
+          end
+        end
+        """)
+      end
+    end
+
+    test "does not raise a compile-time error when emitting an event that is defined" do
+      assert Code.eval_string("""
+             defmodule Emit4Test2 do
+               use Sibyl
+               define_event :defined
+             end
+
+             defmodule SibylTestCompilationHooks5 do
+               use Sibyl
+
+               def hello do
+                 emit Emit4Test2, :defined
+               end
+             end
+             """)
+    end
+
+    test "raises a compile time error if called any other way" do
+      assert_raise Sibyl.BadEmissionError, fn ->
+        Code.eval_string("""
+        defmodule SibylTestCompilationHooks6 do
+          use Sibyl
+
+          def hello do
+            emit 123, :not_defined
           end
         end
         """)


### PR DESCRIPTION
- Refactor and impl. ability to emit events defined in other modules
- Update docs
- Bump version to prep release for cross-function event emission
