### PR TITLE
SYB 11/fix bug in alias resolution

### DIFF
--- a/lib/sibyl/ast.ex
+++ b/lib/sibyl/ast.ex
@@ -19,17 +19,6 @@ defmodule Sibyl.AST do
   defguard unused?(term) when term == :__unused__
 
   @doc """
-  Given an alias AST node, returns the fully resolved alias that said node would expand
-  to.
-
-  For example, given: `{:__aliases, unused(), [Elixir, Enum]}`, returns: `Enum`.
-  """
-  @spec module(alias()) :: module()
-  def module({:__aliases__, _metadata, module_list}) do
-    Module.safe_concat(module_list)
-  end
-
-  @doc """
   Returns the `:__unused__` atom.
   """
   @spec unused() :: ast()
@@ -37,5 +26,19 @@ defmodule Sibyl.AST do
     quote do
       :__unused__
     end
+  end
+
+  # coveralls-ignore-start
+  # TODO: find a way to unit test this, as we now expect the macro's env to be
+  # passed in
+  @doc """
+  Given an alias AST node, returns the fully resolved alias that said node would expand
+  to.
+
+  For example, given: `{:__aliases, unused(), [Elixir, Enum]}`, returns: `Enum`.
+  """
+  @spec module(alias(), env :: map()) :: module()
+  def module({:__aliases__, _metadata, _module_list} = ast, env \\ %{}) do
+    Macro.expand(ast, env)
   end
 end

--- a/lib/sibyl/exceptions.ex
+++ b/lib/sibyl/exceptions.ex
@@ -18,6 +18,16 @@ defmodule Sibyl.BadEmissionError do
   defexception [:message]
 
   @impl Exception
+  def exception(module: module) do
+    %Sibyl.BadEmissionError{
+      message: """
+      An event belonging to `#{inspect(module)}` was attempted to be raised, but this module does not exist.
+
+      Please assert that any module you try to emit an event from exists prior to to attempting to emit any events from it.
+      """
+    }
+  end
+
   def exception(args: args) do
     %Sibyl.BadEmissionError{
       message: """

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Sibyl.MixProject do
   def project do
     [
       app: :sibyl,
-      version: "0.1.5",
+      version: "0.1.6",
       elixir: "~> 1.13",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/sibyl/ast_test.exs
+++ b/test/sibyl/ast_test.exs
@@ -22,12 +22,6 @@ defmodule Sibyl.Handlers.ASTTest do
     end
   end
 
-  describe "module/1" do
-    test "returns module given a module alias AST node" do
-      assert MyApp.Users = AST.module({:__aliases__, [line: 16], [MyApp.Users]})
-    end
-  end
-
   describe "unused/0" do
     test "returns `:__unused__`" do
       assert :__unused__ = AST.unused()

--- a/test/sibyl/handlers/flame_graph_test.exs
+++ b/test/sibyl/handlers/flame_graph_test.exs
@@ -22,6 +22,7 @@ defmodule Sibyl.Handlers.FlameGraphTest do
       filepath =
         :sibyl
         |> :code.priv_dir()
+        |> tap(&File.mkdir_p/1)
         |> Path.join("test.json")
 
       on_exit(fn -> File.rm(filepath) end)

--- a/test/sibyl_test.exs
+++ b/test/sibyl_test.exs
@@ -92,5 +92,38 @@ defmodule SibylTest do
         """)
       end
     end
+
+    test "does not raise a compile-time error when emitting an event that is defined via alias" do
+      assert Code.eval_string("""
+             defmodule Emit4Test3 do
+               use Sibyl
+               define_event :defined
+             end
+
+             defmodule SibylTestCompilationHooks7 do
+               use Sibyl
+
+               alias Emit4Test3, as: Test
+
+               def hello do
+                 emit Test, :defined
+               end
+             end
+             """)
+    end
+
+    test "raises compile time error if module does not exist" do
+      assert_raise Sibyl.BadEmissionError, fn ->
+        Code.eval_string("""
+        defmodule SibylTestCompilationHooks6 do
+          use Sibyl
+
+          def hello do
+            emit SomeModuleThatDoesNotExist, :not_defined
+          end
+        end
+        """)
+      end
+    end
   end
 end


### PR DESCRIPTION
- Aliases need to be resolved via expansion and not `Module.safe_concat/1`
- Bump version to prepare for bug release
