### PR TITLE
SYB 016/plugins

### DIFF
--- a/lib/sibyl/handlers.ex
+++ b/lib/sibyl/handlers.ex
@@ -43,9 +43,14 @@ defmodule Sibyl.Handlers do
   @spec attach_events([Events.event()], handler(), Keyword.t()) :: :ok
   def attach_events(events, handler, opts \\ [])
       when is_list(events) and is_atom(handler) and is_list(opts) do
+    plugin_events =
+      opts
+      |> Keyword.get(:plugins, [])
+      |> Enum.flat_map(& &1.init(opts))
+
     opts
     |> ensure_name()
-    |> :telemetry.attach_many(events, &handler.handle_event/4, opts)
+    |> :telemetry.attach_many(events ++ plugin_events, &handler.handle_event/4, opts)
   end
 
   defp ensure_name(opts) do

--- a/lib/sibyl/plugin.ex
+++ b/lib/sibyl/plugin.ex
@@ -1,0 +1,23 @@
+defmodule Sibyl.Plugin do
+  @moduledoc """
+  Open interface for defining custom Sibyl plugins.
+
+  Note that at the time of writing, all plugins are considered in-development features and no
+  stability or fixed API is guaranteed.
+
+  Sibyl Plugins are intended to be used by providing them as an option when attaching
+  Sibyl handlers like so:
+
+  ```
+  :ok = Sibyl.Handlers.attach_all_events(plugins: [Sibyl.Plugins.Absinthe])
+  :ok = Sibyl.Handlers.attach_module_events(MyApp.Module, plugins: [Sibyl.Plugins.Absinthe])
+  :ok = Sibyl.Handlers.attach_events([[:my_app, :start]], plugins: [Sibyl.Plugins.Absinthe])
+  ```
+  """
+
+  alias Sibyl.Events
+
+  @callback identity :: String.t()
+  @callback init(opts :: Keyword.t()) :: [Events.event()]
+  @callback stop :: :ok | {:error, term()}
+end

--- a/lib/sibyl/plugin.ex
+++ b/lib/sibyl/plugin.ex
@@ -13,11 +13,51 @@ defmodule Sibyl.Plugin do
   :ok = Sibyl.Handlers.attach_module_events(MyApp.Module, plugins: [Sibyl.Plugins.Absinthe])
   :ok = Sibyl.Handlers.attach_events([[:my_app, :start]], plugins: [Sibyl.Plugins.Absinthe])
   ```
+
+  Implementing a plugin is done by defining a module which `use`s `Sibyl.Plugin` and implements
+  the behaviour below.
+
+  Please feel free to refer to `Sibyl.Plugins.Absinthe` or `Sibyl.Plugins.Ecto` for examples of
+  how to implement a plugin.
   """
 
   alias Sibyl.Events
 
+  defmacro __using__(_opts) do
+    prefix =
+      __MODULE__
+      |> Module.split()
+      |> Enum.map(
+        &(&1
+          |> String.downcase()
+          |> String.to_atom())
+      )
+
+    quote do
+      @behaviour unquote(__MODULE__)
+
+      @impl unquote(__MODULE__)
+      def prefix, do: unquote(prefix)
+
+      @impl unquote(__MODULE__)
+      def identity, do: unquote(Enum.join(prefix, "-"))
+
+      @impl unquote(__MODULE__)
+      def stop, do: :telemetry.detach(identity())
+
+      defoverridable prefix: 0, identity: 0, stop: 0
+    end
+  end
+
+  @doc "Event prefix for events emitted/proxied by a given plugin implementation. Defaults to the module's name split"
+  @callback prefix :: [atom()]
+
+  @doc "Unique ID for the plugin. Intended to be used as a mechanism for attaching/detaching proxy `:telemetry` handlers"
   @callback identity :: String.t()
+
+  @doc "Called by Sibyl when attaching a plugin to a handler. Should return a list of events which should be listened to by handlers"
   @callback init(opts :: Keyword.t()) :: [Events.event()]
+
+  @doc "Stops and cleans up any resources used by the plugin. Intended primarily for `:telemetry` handler detachment"
   @callback stop :: :ok | {:error, term()}
 end

--- a/lib/sibyl/plugins/absinthe.ex
+++ b/lib/sibyl/plugins/absinthe.ex
@@ -18,33 +18,44 @@ defmodule Sibyl.Plugins.Absinthe do
 
   # coveralls-ignore-start
 
-  @behaviour Sibyl.Plugin
   @behaviour Sibyl.Handler
-
-  @plugin_prefix [:sibyl, :plugins, :absinthe]
+  use Sibyl.Plugin
 
   @proxy %{
-    [:absinthe, :execute, :operation, :start] => @plugin_prefix ++ [:operation, :start],
-    [:absinthe, :execute, :operation, :stop] => @plugin_prefix ++ [:operation, :stop],
-    [:absinthe, :resolve, :field, :start] => @plugin_prefix ++ [:resolve, :field, :start],
-    [:absinthe, :resolve, :field, :stop] => @plugin_prefix ++ [:resolve, :field, :stop],
-    [:absinthe, :middleware, :batch, :start] => @plugin_prefix ++ [:middleware, :batch, :start],
-    [:absinthe, :middleware, :batch, :stop] => @plugin_prefix ++ [:middleware, :batch, :stop]
+    [:absinthe, :execute, :operation, :start] => [:sibyl, :plugins, :absinthe, :operation, :start],
+    [:absinthe, :execute, :operation, :stop] => [:sibyl, :plugins, :absinthe, :operation, :stop],
+    [:absinthe, :resolve, :field, :start] => [
+      :sibyl,
+      :plugins,
+      :absinthe,
+      :resolve,
+      :field,
+      :start
+    ],
+    [:absinthe, :resolve, :field, :stop] => [:sibyl, :plugins, :absinthe, :resolve, :field, :stop],
+    [:absinthe, :middleware, :batch, :start] => [
+      :sibyl,
+      :plugins,
+      :absinthe,
+      :middleware,
+      :batch,
+      :start
+    ],
+    [:absinthe, :middleware, :batch, :stop] => [
+      :sibyl,
+      :plugins,
+      :absinthe,
+      :middleware,
+      :batch,
+      :stop
+    ]
   }
-
-  @impl Sibyl.Plugin
-  def identity, do: Enum.join(@plugin_prefix, "-")
 
   @impl Sibyl.Plugin
   def init(_opts \\ []) do
     stop()
     :telemetry.attach_many(identity(), Map.keys(@proxy), &__MODULE__.handle_event/4, {})
     Map.values(@proxy)
-  end
-
-  @impl Sibyl.Plugin
-  def stop do
-    :telemetry.detach(identity())
   end
 
   @impl Sibyl.Handler

--- a/lib/sibyl/plugins/absinthe.ex
+++ b/lib/sibyl/plugins/absinthe.ex
@@ -1,0 +1,83 @@
+defmodule Sibyl.Plugins.Absinthe do
+  @moduledoc """
+  Sibyl plugin module for listening to telemetry events emitted by Absinthe. See docs for `Sibyl.Plugin`
+  for more information about plugins themselves.
+
+  This plugin will extend Sibyl and enable any configured Sibyl handler to listen to various events emitted
+  by `Absinthe` including field resolution, query execution, and batching.
+
+  Use via `Sibyl.Handlers.attach_all_events(plugins: [Sibyl.Plugins.Absinthe])`.
+  """
+
+  @behaviour Sibyl.Plugin
+  @behaviour Sibyl.Handler
+
+  @plugin_prefix [:sibyl, :plugins, :absinthe]
+
+  @proxy %{
+    [:absinthe, :execute, :operation, :start] => @plugin_prefix ++ [:operation, :start],
+    [:absinthe, :execute, :operation, :stop] => @plugin_prefix ++ [:operation, :stop],
+    [:absinthe, :resolve, :field, :start] => @plugin_prefix ++ [:resolve, :field, :start],
+    [:absinthe, :resolve, :field, :stop] => @plugin_prefix ++ [:resolve, :field, :stop],
+    [:absinthe, :middleware, :batch, :start] => @plugin_prefix ++ [:middleware, :batch, :start],
+    [:absinthe, :middleware, :batch, :stop] => @plugin_prefix ++ [:middleware, :batch, :stop]
+  }
+
+  @impl Sibyl.Plugin
+  def identity, do: Enum.join(@plugin_prefix, "-")
+
+  @impl Sibyl.Plugin
+  def init(_opts \\ []) do
+    stop()
+    :telemetry.attach_many(identity(), Map.keys(@proxy), &__MODULE__.handle_event/4, {})
+    Map.values(@proxy)
+  end
+
+  @impl Sibyl.Plugin
+  def stop do
+    :telemetry.detach(identity())
+  end
+
+  @impl Sibyl.Handler
+  def handle_event(event, measurement, metadata, _config) do
+    base_metadata = %{node: node()}
+
+    Sibyl.Events.emit(
+      @proxy[event],
+      Map.put(measurement, :monotonic_time, System.monotonic_time()),
+      Map.merge(base_metadata, parse_event(event, metadata))
+    )
+  rescue
+    _error -> :ok
+  catch
+    _error -> :ok
+  end
+
+  defp parse_event([:absinthe, :execute | _rest], metadata) do
+    document = Keyword.get(metadata.options, :document)
+
+    %{
+      document: document,
+      args: Keyword.get(metadata.options, :variables),
+      context: Keyword.get(metadata.options, :context),
+      event_name: "query:" <> (Keyword.get(metadata.options, :operation_name) || "anonymous")
+    }
+  end
+
+  defp parse_event([:absinthe, :resolve | _rest], metadata) do
+    %{
+      schema: metadata.resolution.schema,
+      args: metadata.resolution.arguments,
+      value: inspect(metadata.resolution.value),
+      event_name: "field:" <> (metadata.resolution.path |> List.first() |> Map.get(:name))
+    }
+  end
+
+  defp parse_event([:absinthe, :middleware, :batch | _rest], metadata) do
+    arity = 2
+    [module, function | _rest] = Tuple.to_list(metadata.batch_fun)
+    mfa = "#{inspect(module)}.#{function}/#{arity}"
+
+    %{event_name: "batch:" <> mfa, mfa: mfa, args: metadata.batch_data}
+  end
+end

--- a/lib/sibyl/plugins/absinthe.ex
+++ b/lib/sibyl/plugins/absinthe.ex
@@ -7,7 +7,16 @@ defmodule Sibyl.Plugins.Absinthe do
   by `Absinthe` including field resolution, query execution, and batching.
 
   Use via `Sibyl.Handlers.attach_all_events(plugins: [Sibyl.Plugins.Absinthe])`.
+
+  > #### Note {: .warning}
+  >
+  > This plugin is very much still a work in progress, and should not be used in production code!
+  >
+  > Additionally, as this plugin is still a work in progress, it is not guaranteed to be stable. There
+  > are no unit tests provided to ensure this module does not change.
   """
+
+  # coveralls-ignore-start
 
   @behaviour Sibyl.Plugin
   @behaviour Sibyl.Handler

--- a/lib/sibyl/plugins/ecto.ex
+++ b/lib/sibyl/plugins/ecto.ex
@@ -1,0 +1,105 @@
+defmodule Sibyl.Plugins.Ecto do
+  @moduledoc """
+  Sibyl plugin module for listening to telemetry events emitted by Ecto. See docs for `Sibyl.Plugin`
+  for more information about plugins themselves.
+
+  This plugin will extend Sibyl and enable any configured Sibyl handler to listen to various events emitted
+  by `Ecto` including field resolution, query execution, and batching.
+
+  Use via `Sibyl.Handlers.attach_all_events(plugins: [Sibyl.Plugins.Ecto])`.
+
+  > #### Note {: .warning}
+  >
+  > This plugin is very much still a work in progress, and should not be used in production code!
+  > This is due to the fact that Sibyl doesn't expose an easy way to skew the time of events.
+  > As a result, any spans containing Ecto functions will be very skewed and offset. Ecto spans alone
+  > work fine however, so this is a workable first PoC
+  """
+
+  @behaviour Sibyl.Plugin
+  @behaviour Sibyl.Handler
+
+  @plugin_prefix [:sibyl, :plugins]
+
+  @proxy [[:repo, :query]]
+
+  @impl Sibyl.Plugin
+  def identity, do: Enum.join(@plugin_prefix, "-")
+
+  @impl Sibyl.Plugin
+  def init(opts \\ []) do
+    stop()
+
+    prefix = opts[:ecto_prefix]
+
+    unless is_atom(opts[:ecto_prefix]) do
+      raise ArgumentError,
+        message: """
+        Ecto Telemetry events require an atom `:prefix` to be provided, in order to be listened to.
+        """
+    end
+
+    ecto_events = Enum.map(@proxy, &[prefix | &1])
+
+    sibyl_events =
+      ecto_events
+      |> Enum.map(&(@plugin_prefix ++ &1))
+      |> Enum.flat_map(fn event ->
+        [event ++ [:start], event ++ [:end], event ++ [:exception]]
+      end)
+
+    :telemetry.attach_many(identity(), ecto_events, &__MODULE__.handle_event/4, {})
+    sibyl_events
+  end
+
+  @impl Sibyl.Plugin
+  def stop do
+    :telemetry.detach(identity())
+  end
+
+  @impl Sibyl.Handler
+  def handle_event(
+        event,
+        %{query_time: query_time, total_time: total_time} = measurement,
+        metadata,
+        _config
+      ) do
+    now = System.monotonic_time()
+
+    start_metadata = %{
+      node: node(),
+      repo: metadata.repo,
+      query: metadata.query,
+      params: metadata.params,
+      start_time: now - total_time
+    }
+
+    stop_metadata = %{
+      result: elem(metadata.result, 1),
+      stacktrace: metadata.stacktrace,
+      stop_time: now,
+      total_time: total_time,
+      query_time: query_time
+    }
+
+    stop_event = (match?({:ok, _result}, metadata.result) && [:stop]) || [:exception]
+
+    :ok =
+      Sibyl.Events.emit(
+        @plugin_prefix ++ event ++ [:start],
+        Map.put(measurement, :monotonic_time, now - total_time),
+        start_metadata
+      )
+
+    :ok =
+      Sibyl.Events.emit(
+        @plugin_prefix ++ event ++ stop_event,
+        Map.put(measurement, :monotonic_time, now),
+        stop_metadata
+      )
+  rescue
+    _error -> :ok
+  catch
+    _error -> :ok
+  end
+end

--- a/lib/sibyl/plugins/ecto.ex
+++ b/lib/sibyl/plugins/ecto.ex
@@ -14,7 +14,12 @@ defmodule Sibyl.Plugins.Ecto do
   > This is due to the fact that Sibyl doesn't expose an easy way to skew the time of events.
   > As a result, any spans containing Ecto functions will be very skewed and offset. Ecto spans alone
   > work fine however, so this is a workable first PoC
+  >
+  > Additionally, as this plugin is still a work in progress, it is not guaranteed to be stable. There
+  > are no unit tests provided to ensure this module does not change.
   """
+
+  # coveralls-ignore-start
 
   @behaviour Sibyl.Plugin
   @behaviour Sibyl.Handler

--- a/mix.exs
+++ b/mix.exs
@@ -12,7 +12,7 @@ defmodule Sibyl.MixProject do
       dialyzer: [
         plt_add_apps: [:iex, :mix, :ex_unit],
         plt_file: {:no_warn, "priv/plts/dialyzer.plt"},
-        flags: [:error_handling, :race_conditions]
+        flags: [:error_handling]
       ],
       test_coverage: [tool: ExCoveralls],
       preferred_cli_env: [

--- a/test/sibyl/handlers_test.exs
+++ b/test/sibyl/handlers_test.exs
@@ -41,22 +41,12 @@ defmodule Sibyl.Handlers.HandlersTest do
     test "any provided plugins are able to add custom events", ctx do
       Code.eval_string("""
       defmodule PluginTest do
-        @behaviour Sibyl.Plugin
-
-        @plugin_prefix [:sibyl, :plugins, :absinthe]
-
-        @impl Sibyl.Plugin
-        def identity, do: Enum.join(@plugin_prefix, "-")
+        use Sibyl.Plugin
 
         @impl Sibyl.Plugin
         def init(_opts \\\\ []) do
           stop()
           [[:plugin, :test]]
-        end
-
-        @impl Sibyl.Plugin
-        def stop do
-          :ok
         end
       end
       """)


### PR DESCRIPTION
- Allow events to be extended by provided plugins, if any
- Bootstrap plugin behaviour
- Initial spike of an Absinthe plugin
- Initial spike of an Ecto plugin

![image](https://github.com/Vetspire/sibyl/assets/15597865/018b3c99-fbbc-451e-b1c2-f90d36abe4db)

![image](https://github.com/Vetspire/sibyl/assets/15597865/56610186-913b-4ba3-b4b2-d42883ad69a5)

