### PR TITLE
Rename guards and predicates to follow Elixir conventions

### DIFF
--- a/lib/sibyl.ex
+++ b/lib/sibyl.ex
@@ -263,7 +263,7 @@ defmodule Sibyl do
         reraise Sibyl.BadEmissionError.exception(module: module), __STACKTRACE__
     end
 
-    unless Sibyl.Events.is_event(module, Sibyl.Events.build_event(module, nil, nil, event)) do
+    unless Sibyl.Events.event?(module, Sibyl.Events.build_event(module, nil, nil, event)) do
       raise Sibyl.UndefinedEventError, event: event, module: module
     end
 
@@ -280,7 +280,7 @@ defmodule Sibyl do
   defmacro emit(event, measurements, metadata, unused) when is_atom(event) and unused?(unused) do
     module = __CALLER__.module
 
-    unless Sibyl.Events.is_event(module, Sibyl.Events.build_event(module, nil, nil, event)) do
+    unless Sibyl.Events.event?(module, Sibyl.Events.build_event(module, nil, nil, event)) do
       raise Sibyl.UndefinedEventError, event: event, module: module
     end
 

--- a/lib/sibyl/dynamic.ex
+++ b/lib/sibyl/dynamic.ex
@@ -73,7 +73,7 @@ defmodule Sibyl.Dynamic do
   # This will be easy enough to do; but for now, this works.
   @doc false
   @spec handle_trace(term(), stack :: list()) :: list()
-  def handle_trace(message, stack) when trace?(message) and type?(message, :call) do
+  def handle_trace(message, stack) when is_trace(message) and is_type(message, :call) do
     {module, function, arity} = parse_mfa!(message)
 
     module
@@ -83,7 +83,7 @@ defmodule Sibyl.Dynamic do
     stack
   end
 
-  def handle_trace(message, stack) when trace?(message) and type?(message, :return_from) do
+  def handle_trace(message, stack) when is_trace(message) and is_type(message, :return_from) do
     {module, function, arity} = parse_mfa!(message)
     return = parse_return!(message)
 

--- a/lib/sibyl/dynamic/guards.ex
+++ b/lib/sibyl/dynamic/guards.ex
@@ -7,7 +7,7 @@ defmodule Sibyl.Dynamic.Guards do
   Returns `true` if given term is a message sent by the Erlang `:dbg` module for
   function and function-return traces.
   """
-  defguard trace?(message)
+  defguard is_trace(message)
            when elem(message, 0) == :trace and
                   (tuple_size(message) == 4 or
                      tuple_size(message) == 5)
@@ -16,5 +16,5 @@ defmodule Sibyl.Dynamic.Guards do
   Returns `true` if given term is a message sent by the Erlang `:dbg` module and if
   the message type corresponds to the given type.
   """
-  defguard type?(message, type) when elem(message, 2) == type
+  defguard is_type(message, type) when elem(message, 2) == type
 end

--- a/lib/sibyl/events.ex
+++ b/lib/sibyl/events.ex
@@ -113,8 +113,8 @@ defmodule Sibyl.Events do
   @doc """
   Returns true if event was defined.
   """
-  @spec is_event(event()) :: boolean()
-  def is_event(event) when is_list(event) do
+  @spec event?(event()) :: boolean()
+  def event?(event) when is_list(event) do
     event in reflect()
   end
 
@@ -122,8 +122,8 @@ defmodule Sibyl.Events do
   Given a module that may, or may not, `use Sibyl` as well as an event, returns
   true if said module defines the given event.
   """
-  @spec is_event(module(), event()) :: boolean()
-  def is_event(module, event) when is_atom(module) and is_list(event) do
+  @spec event?(module(), event()) :: boolean()
+  def event?(module, event) when is_atom(module) and is_list(event) do
     event in reflect(module)
   end
 

--- a/test/sibyl/dynamic/guard_test.exs
+++ b/test/sibyl/dynamic/guard_test.exs
@@ -6,30 +6,30 @@ defmodule Sibyl.Dynamic.GuardsTest do
   return_message = {:trace, self(), :return_from, {Enum, :map, 2}, []}
   bad_messages = [:hello, "hello", 1, self(), DateTime.utc_now(), [], {1}, {:trace, :wrong_size}]
 
-  describe "trace?/1" do
+  describe "is_trace/1" do
     for {type, message} <- [call: call_message, return_from: return_message] do
       test "returns true given message that looks like it came from `:dbg.trace` of type #{type}" do
-        assert Guards.trace?(unquote(Macro.escape(message)))
+        assert Guards.is_trace(unquote(Macro.escape(message)))
       end
     end
 
     for message <- bad_messages do
       test "returns false given `#{inspect(message)}`" do
-        refute Guards.trace?({:hello})
+        refute Guards.is_trace({:hello})
       end
     end
   end
 
-  describe "type?/1" do
+  describe "is_type/1" do
     for {type, message} <- [call: call_message, return_from: return_message] do
       test "returns true given message of type `#{type}` when asserting type `#{type}`" do
-        assert Guards.type?(unquote(Macro.escape(message)), unquote(type))
+        assert Guards.is_type(unquote(Macro.escape(message)), unquote(type))
       end
     end
 
     for {type, message} <- [return_from: call_message, call: return_message] do
       test "returns false given message of any other type when asserting type `#{type}`" do
-        refute Guards.type?(unquote(Macro.escape(message)), unquote(type))
+        refute Guards.is_type(unquote(Macro.escape(message)), unquote(type))
       end
     end
   end

--- a/test/sibyl/events_test.exs
+++ b/test/sibyl/events_test.exs
@@ -111,9 +111,9 @@ defmodule Sibyl.Handlers.EventsTest do
     end
   end
 
-  describe "is_event/1" do
+  describe "event?/1" do
     test "returns false when event is not a valid event" do
-      refute Events.is_event([:my_app, :something_random, :test])
+      refute Events.event?([:my_app, :something_random, :test])
     end
 
     test "returns list of all events which are manually defined in given module" do
@@ -124,13 +124,13 @@ defmodule Sibyl.Handlers.EventsTest do
         end
       """)
 
-      assert Events.is_event([:my_app, :something_random, :diff_test])
+      assert Events.event?([:my_app, :something_random, :diff_test])
     end
   end
 
-  describe "is_event/2" do
+  describe "event?/2" do
     test "returns false when event is not a valid event" do
-      refute Events.is_event(Enum, [:my_app, :something_random, :test])
+      refute Events.event?(Enum, [:my_app, :something_random, :test])
     end
 
     test "returns true if event is a valid event and also defined in given module" do
@@ -141,8 +141,8 @@ defmodule Sibyl.Handlers.EventsTest do
         end
       """)
 
-      assert Events.is_event(MyApp.ReflectTestSix, [:my_app, :something_random, :sixth_test])
-      refute Events.is_event(Enum, [:my_app, :something_random, :sixth_test])
+      assert Events.event?(MyApp.ReflectTestSix, [:my_app, :something_random, :sixth_test])
+      refute Events.event?(Enum, [:my_app, :something_random, :sixth_test])
     end
   end
 


### PR DESCRIPTION
Ended up with separate PRs, so if you decide not to include style changes you won't have to