### PR TITLE
Support Erlang-style modules

### DIFF
--- a/lib/sibyl.ex
+++ b/lib/sibyl.ex
@@ -247,12 +247,13 @@ defmodule Sibyl do
   to emit (unless the event was specified as a list of atoms), to ensure that the event was
   properly defined by `Sibyl` before use.
   """
-  @spec emit(AST.alias(), Events.event(), measurements(), metadata()) :: AST.ast()
+  @spec emit(AST.module_ast(), Events.event(), measurements(), metadata()) :: AST.ast()
   @spec emit(Events.sibyl_event(), measurements(), metadata(), AST.unused()) :: AST.ast()
   @spec emit(Events.event(), measurements(), metadata(), AST.unused()) :: AST.ast()
   defmacro emit(arg1, arg2 \\ Macro.escape(%{}), arg3 \\ Macro.escape(%{}), arg4 \\ unused())
 
-  defmacro emit(module, event, measurements, metadata) when alias?(module) and is_atom(event) do
+  defmacro emit(module, event, measurements, metadata)
+           when is_module_ast(module) and is_atom(event) do
     metadata = (unused?(metadata) && Macro.escape(%{})) || metadata
     module = AST.module(module, __CALLER__)
 

--- a/lib/sibyl/ast.ex
+++ b/lib/sibyl/ast.ex
@@ -4,14 +4,16 @@ defmodule Sibyl.AST do
   """
 
   @type ast() :: term()
-  @type alias() :: {:__aliases__, term(), [atom()]}
+  @type module_ast() :: {:__aliases__, term(), [atom()]} | atom()
   @type unused() :: :__unused__
 
   @doc """
   Returns true if the given argument is an Elixir AST node representing a module alias
   such as `Enum`.
   """
-  defguard alias?(ast) when is_tuple(ast) and elem(ast, 0) == :__aliases__
+  defguard is_module_ast(ast)
+           when is_atom(ast) or
+                  (is_tuple(ast) and tuple_size(ast) == 3 and elem(ast, 0) == :__aliases__)
 
   @doc """
   Returns true if the given argument is equal to `:__unused__`. Primarily used internally.
@@ -37,7 +39,7 @@ defmodule Sibyl.AST do
 
   For example, given: `{:__aliases, unused(), [Elixir, Enum]}`, returns: `Enum`.
   """
-  @spec module(alias(), Macro.Env.t()) :: module()
+  @spec module(module_ast(), Macro.Env.t()) :: module()
   def module({:__aliases__, _metadata, _module_list} = ast, env) do
     case Macro.expand(ast, env) do
       module when is_atom(module) ->

--- a/test/sibyl/ast_test.exs
+++ b/test/sibyl/ast_test.exs
@@ -2,13 +2,17 @@ defmodule Sibyl.Handlers.ASTTest do
   use ExUnit.Case
   require Sibyl.AST, as: AST
 
-  describe "alias?/1" do
+  describe "is_module_ast/1" do
     test "returns true when given an AST node which is an alias" do
-      assert AST.alias?({:__aliases__, [line: 16], [MyApp, Users]})
+      assert AST.is_module_ast({:__aliases__, [line: 16], [MyApp, Users]})
     end
 
-    test "returns false given anything else" do
-      refute AST.alias?(:atom)
+    test "returns true when module name is non-:Elixir prefixed module name" do
+      assert AST.is_module_ast(:module)
+    end
+
+    test "returns false for everything else" do
+      refute AST.is_module_ast(123)
     end
   end
 


### PR DESCRIPTION
```elixir
defmodule :my_module do
  use Sybil
end
```
Is a valid code